### PR TITLE
Fixing Github actions error in app build

### DIFF
--- a/.github/workflows/eas-build.yaml
+++ b/.github/workflows/eas-build.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-          cache-dependency-path: apps/mobile/package-lock.json
+          cache-dependency-path: app/package-lock.json
 
       - name: Install deps
         run: npm ci


### PR DESCRIPTION
ci: point setup-node cache-dependency-path to app/package-lock.json